### PR TITLE
Update dropboxlist.php

### DIFF
--- a/views/admin/index/dropboxlist.php
+++ b/views/admin/index/dropboxlist.php
@@ -5,6 +5,14 @@
     <?php if (!$fileNames): ?>
         <p><strong><?php echo __('No files have been uploaded to the dropbox.'); ?></strong></p>
     <?php else: ?>
+               <!-- When processing more than 1000 files, they are not placed into the
+                selected Collection, and no tags are applied.  To avoid this,
+                show the number of files in the Dropbox, and if there are more
+                than 1000, put up an alert -->
+        <?php echo '<h3>File count:'.sizeof($fileNames)."</h3>";
+                if (sizeof($fileNames)>999) :
+                echo "<h4 class=error>Too many files - must be less than 1000.  Filter to reduce total</h4>";
+                endif; ?>
         <script type="text/javascript">
             function dropboxSelectAllCheckboxes(checked) {
                 jQuery('#dropbox-file-checkboxes tr:visible input').each(function() {


### PR DESCRIPTION
Introduced an item count, partially because it is useful to know, but mainly because there are issues with processing more than ~1000 items at a time.  When there are too many items, the collection and tag fields are not processed, with the result that all items are added with no collection and no tags.

I suspect this is due to the length limit of an HTTP POST request, and that the POST content is truncated.  The list of files to be processed comes before the other fields, and hence they drop off the bottom of the request.  A better approach may be to include a hidden field with a name of "upload complete" or similar, and if this is not received, throw an error that the POST data has been truncated.

Here's a (cropped to just the last few entries) sample of a POST payload:

&dropbox-files%5B%5D=IMG_7065.JPG&dropbox-files%5B%5D=IMG_7066.JPG&dropbox-files%5B%5D=IMG_7067.JPG&dropbox-files%5B%5D=IMG_7068.JPG&dropbox-files%5B%5D=IMG_7069.JPG&dropbox-files%5B%5D=IMG_7070.JPG&dropbox-files%5B%5D=IMG_7071.JPG&dropbox-files%5B%5D=IMG_7072.JPG&dropbox-files%5B%5D=IMG_7073.JPG&submit=Upload+Files+as+Items&dropbox-public=0&dropbox-public=1&dropbox-featured=0&dropbox-collection-id=375&dropbox-tags=2010

Chrome inspection provides a clearer format:

dropbox-files[]: IMG_7068.JPG
dropbox-files[]: IMG_7069.JPG
dropbox-files[]: IMG_7070.JPG
dropbox-files[]: IMG_7071.JPG
dropbox-files[]: IMG_7072.JPG
dropbox-files[]: IMG_7073.JPG
submit: Upload Files as Items
dropbox-public: 0
dropbox-public: 1
dropbox-featured: 0
dropbox-collection-id: 375
dropbox-tags: 2010

With ~550 files to upload, my payload is 19KB.  

My php.,ini defines "post_max_size = 500M", and Apache has no limits applied.  